### PR TITLE
Remove dependency on `winapi` 0.2.x.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ fuchsia-zircon-sys = "0.3.2"
 libc   = "0.2.54"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.3.9"
 windows-sys = "0.48.0"
 miow   = "0.6.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ fuchsia-zircon-sys = "0.3.2"
 libc   = "0.2.54"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2.6"
-miow   = "0.2.2"
-kernel32-sys = "0.2"
+winapi = "0.3.9"
+windows-sys = "0.48.0"
+miow   = "0.6.0"
 
 [dev-dependencies]
 env_logger = { version = "0.4.0", default-features = false }

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -512,7 +512,6 @@ impl ops::Sub for PollOpt {
     }
 }
 
-#[deprecated(since = "0.6.10", note = "removed")]
 #[cfg(feature = "with-deprecated")]
 #[doc(hidden)]
 impl ops::Not for PollOpt {
@@ -999,7 +998,6 @@ impl<T: Into<Ready>> ops::SubAssign<T> for Ready {
     }
 }
 
-#[deprecated(since = "0.6.10", note = "removed")]
 #[cfg(feature = "with-deprecated")]
 #[doc(hidden)]
 impl ops::Not for Ready {

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,5 +1,5 @@
 // Re-export the io::Result / Error types for convenience
-pub use std::io::{Read, Write, Result, Error, ErrorKind};
+pub use std::io::{Result, Error, ErrorKind};
 
 // TODO: Delete this
 /// A helper trait to provide the map_non_block function on Results.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 
 // Many of mio's public methods violate this lint, but they can't be fixed
 // without a breaking change.
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::trivially_copy_pass_by_ref))]
+#![cfg_attr(clippy, allow(clippy::trivially_copy_pass_by_ref))]
 
 //! A fast, low-level IO library for Rust focusing on non-blocking APIs, event
 //! notification, and other useful utilities for building high performance IO
@@ -127,7 +127,7 @@ extern crate miow;
 extern crate winapi;
 
 #[cfg(windows)]
-extern crate kernel32;
+extern crate windows_sys;
 
 #[macro_use]
 extern crate log;
@@ -192,9 +192,7 @@ pub mod event {
     pub use super::event_imp::{Event, Evented};
 }
 
-pub use event::{
-    Events,
-};
+pub use event::Events;
 
 #[deprecated(since = "0.6.5", note = "use events:: instead")]
 #[cfg(feature = "with-deprecated")]
@@ -214,9 +212,7 @@ pub use io::deprecated::would_block;
 #[cfg(all(unix, not(target_os = "fuchsia")))]
 pub mod unix {
     //! Unix only extensions
-    pub use sys::{
-        EventedFd,
-    };
+    pub use sys::EventedFd;
     pub use sys::unix::UnixReady;
 }
 
@@ -229,9 +225,7 @@ pub mod fuchsia {
     //! This module depends on the [magenta-sys crate](https://crates.io/crates/magenta-sys)
     //! and so might introduce breaking changes, even on minor releases,
     //! so long as that crate remains unstable.
-    pub use sys::{
-        EventedHandle,
-    };
+    pub use sys::EventedHandle;
     pub use sys::fuchsia::{FuchsiaReady, zx_signals_t};
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,9 +124,6 @@ extern crate libc;
 extern crate miow;
 
 #[cfg(windows)]
-extern crate winapi;
-
-#[cfg(windows)]
 extern crate windows_sys;
 
 #[macro_use]

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1151,7 +1151,7 @@ impl Poll {
     }
 
     #[inline]
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::if_same_then_else))]
+    #[cfg_attr(clippy, allow(clippy::if_same_then_else))]
     fn poll2(&self, events: &mut Events, mut timeout: Option<Duration>, interruptible: bool) -> io::Result<usize> {
         // Compute the timeout value passed to the system selector. If the
         // readiness queue has pending nodes, we still want to poll the system

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -139,7 +139,6 @@
 use std::io;
 use std::os::windows::prelude::*;
 
-use winapi::um::winbase::{FILE_SKIP_COMPLETION_PORT_ON_SUCCESS, FILE_SKIP_SET_EVENT_ON_HANDLE};
 use windows_sys::Win32::Foundation::{FALSE, HANDLE, TRUE};
 use windows_sys::Win32::Storage::FileSystem::SetFileCompletionNotificationModes;
 use windows_sys::Win32::System::IO::CancelIoEx;
@@ -174,6 +173,9 @@ unsafe fn cancel(socket: &AsRawSocket,
 }
 
 unsafe fn no_notify_on_instant_completion(handle: HANDLE) -> io::Result<()> {
+    const FILE_SKIP_COMPLETION_PORT_ON_SUCCESS: u8 = 1;
+    const FILE_SKIP_SET_EVENT_ON_HANDLE: u8 = 2;
+
     let flags = FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE;
 
     let r = SetFileCompletionNotificationModes(handle, flags);

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -139,8 +139,10 @@
 use std::io;
 use std::os::windows::prelude::*;
 
-use kernel32;
-use winapi;
+use winapi::um::winbase::{FILE_SKIP_COMPLETION_PORT_ON_SUCCESS, FILE_SKIP_SET_EVENT_ON_HANDLE};
+use windows_sys::Win32::Foundation::{FALSE, HANDLE, TRUE};
+use windows_sys::Win32::Storage::FileSystem::SetFileCompletionNotificationModes;
+use windows_sys::Win32::System::IO::CancelIoEx;
 
 mod awakener;
 #[macro_use]
@@ -162,24 +164,20 @@ enum Family {
 
 unsafe fn cancel(socket: &AsRawSocket,
                  overlapped: &Overlapped) -> io::Result<()> {
-    let handle = socket.as_raw_socket() as winapi::HANDLE;
-    let ret = kernel32::CancelIoEx(handle, overlapped.as_mut_ptr());
-    if ret == 0 {
+    let handle = socket.as_raw_socket() as HANDLE;
+    let success = CancelIoEx(handle, overlapped.as_mut_ptr());
+    if success == FALSE {
         Err(io::Error::last_os_error())
     } else {
         Ok(())
     }
 }
 
-unsafe fn no_notify_on_instant_completion(handle: winapi::HANDLE) -> io::Result<()> {
-    // TODO: move those to winapi
-    const FILE_SKIP_COMPLETION_PORT_ON_SUCCESS: winapi::UCHAR = 1;
-    const FILE_SKIP_SET_EVENT_ON_HANDLE: winapi::UCHAR = 2;
-
+unsafe fn no_notify_on_instant_completion(handle: HANDLE) -> io::Result<()> {
     let flags = FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE;
 
-    let r = kernel32::SetFileCompletionNotificationModes(handle, flags);
-    if r == winapi::TRUE {
+    let r = SetFileCompletionNotificationModes(handle, flags);
+    if r == TRUE {
         Ok(())
     } else {
         Err(io::Error::last_os_error())

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -9,13 +9,13 @@ use std::time::Duration;
 
 use lazycell::AtomicLazyCell;
 
-use winapi::shared::winerror;
 use miow;
 use miow::iocp::{CompletionPort, CompletionStatus};
 
 use event_imp::{Event, Evented, Ready};
 use poll::{self, Poll};
 use sys::windows::buffer_pool::BufferPool;
+use windows_sys::Win32::Foundation::WAIT_TIMEOUT;
 use windows_sys::Win32::System::IO::{OVERLAPPED, OVERLAPPED_ENTRY};
 use {Token, PollOpt};
 
@@ -79,7 +79,7 @@ impl Selector {
         trace!("polling IOCP");
         let n = match self.inner.port.get_many(&mut events.statuses, timeout) {
             Ok(statuses) => statuses.len(),
-            Err(ref e) if e.raw_os_error() == Some(winerror::WAIT_TIMEOUT as i32) => 0,
+            Err(ref e) if e.raw_os_error() == Some(WAIT_TIMEOUT as i32) => 0,
             Err(e) => return Err(e),
         };
 

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -9,13 +9,14 @@ use std::time::Duration;
 
 use lazycell::AtomicLazyCell;
 
-use winapi::*;
+use winapi::shared::winerror;
 use miow;
 use miow::iocp::{CompletionPort, CompletionStatus};
 
 use event_imp::{Event, Evented, Ready};
 use poll::{self, Poll};
 use sys::windows::buffer_pool::BufferPool;
+use windows_sys::Win32::System::IO::{OVERLAPPED, OVERLAPPED_ENTRY};
 use {Token, PollOpt};
 
 /// Each Selector has a globally unique(ish) ID associated with it. This ID
@@ -78,7 +79,7 @@ impl Selector {
         trace!("polling IOCP");
         let n = match self.inner.port.get_many(&mut events.statuses, timeout) {
             Ok(statuses) => statuses.len(),
-            Err(ref e) if e.raw_os_error() == Some(WAIT_TIMEOUT as i32) => 0,
+            Err(ref e) if e.raw_os_error() == Some(winerror::WAIT_TIMEOUT as i32) => 0,
             Err(e) => return Err(e),
         };
 
@@ -461,16 +462,10 @@ impl Events {
 
 macro_rules! overlapped2arc {
     ($e:expr, $t:ty, $($field:ident).+) => ({
-        let offset = offset_of!($t, $($field).+);
+        let offset = mem::offset_of!($t, $($field).+);
         debug_assert!(offset < mem::size_of::<$t>());
         FromRawArc::from_raw(($e as usize - offset) as *mut $t)
     })
-}
-
-macro_rules! offset_of {
-    ($t:ty, $($field:ident).+) => (
-        &(*(0 as *const $t)).$($field).+ as *const _ as usize
-    )
 }
 
 // See sys::windows module docs for why this exists.

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -1,22 +1,23 @@
 use std::fmt;
-use std::io::{self, Read, ErrorKind};
+use std::io::{self, ErrorKind, Read};
 use std::mem;
-use std::net::{self, SocketAddr, Shutdown};
+use std::net::{self, Shutdown, SocketAddr};
 use std::os::windows::prelude::*;
 use std::sync::{Mutex, MutexGuard};
 use std::time::Duration;
 
+use iovec::IoVec;
 use miow::iocp::CompletionStatus;
 use miow::net::*;
 use net2::{TcpBuilder, TcpStreamExt as Net2TcpExt};
-use winapi::*;
-use iovec::IoVec;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::System::IO::OVERLAPPED_ENTRY;
 
-use {poll, Ready, Poll, PollOpt, Token};
 use event::Evented;
 use sys::windows::from_raw_arc::FromRawArc;
 use sys::windows::selector::{Overlapped, ReadyBinding};
 use sys::windows::Family;
+use {poll, Poll, PollOpt, Ready, Token};
 
 pub struct TcpStream {
     /// Separately stored implementation to ensure that the `Drop`
@@ -85,15 +86,14 @@ struct ListenerInner {
 }
 
 enum State<T, U> {
-    Empty,              // no I/O operation in progress
-    Pending(T),         // an I/O operation is in progress
-    Ready(U),           // I/O has finished with this value
-    Error(io::Error),   // there was an I/O error
+    Empty,            // no I/O operation in progress
+    Pending(T),       // an I/O operation is in progress
+    Ready(U),         // I/O has finished with this value
+    Error(io::Error), // there was an I/O error
 }
 
 impl TcpStream {
-    fn new(socket: net::TcpStream,
-           deferred_connect: Option<SocketAddr>) -> TcpStream {
+    fn new(socket: net::TcpStream, deferred_connect: Option<SocketAddr>) -> TcpStream {
         TcpStream {
             registration: Mutex::new(None),
             imp: StreamImp {
@@ -113,8 +113,7 @@ impl TcpStream {
         }
     }
 
-    pub fn connect(socket: net::TcpStream, addr: &SocketAddr)
-                   -> io::Result<TcpStream> {
+    pub fn connect(socket: net::TcpStream, addr: &SocketAddr) -> io::Result<TcpStream> {
         socket.set_nonblocking(true)?;
         Ok(TcpStream::new(socket, Some(*addr)))
     }
@@ -132,7 +131,11 @@ impl TcpStream {
     }
 
     pub fn try_clone(&self) -> io::Result<TcpStream> {
-        self.imp.inner.socket.try_clone().map(|s| TcpStream::new(s, None))
+        self.imp
+            .inner
+            .socket
+            .try_clone()
+            .map(|s| TcpStream::new(s, None))
     }
 
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
@@ -188,16 +191,18 @@ impl TcpStream {
     }
 
     pub fn set_linger(&self, dur: Option<Duration>) -> io::Result<()> {
+        #[allow(unstable_name_collisions)]
         self.imp.inner.socket.set_linger(dur)
     }
 
     pub fn linger(&self) -> io::Result<Option<Duration>> {
+        #[allow(unstable_name_collisions)]
         self.imp.inner.socket.linger()
     }
 
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         if let Some(e) = self.imp.inner.socket.take_error()? {
-            return Ok(Some(e))
+            return Ok(Some(e));
         }
 
         // If the syscall didn't return anything then also check to see if we've
@@ -236,8 +241,7 @@ impl TcpStream {
         match me.read {
             // Empty == we're not associated yet, and if we're pending then
             // these are both cases where we return "would block"
-            State::Empty |
-            State::Pending(()) => return Err(io::ErrorKind::WouldBlock.into()),
+            State::Empty | State::Pending(()) => return Err(io::ErrorKind::WouldBlock.into()),
 
             // If we got a delayed error as part of a `read_overlapped` below,
             // return that here. Also schedule another read in case it was
@@ -248,7 +252,7 @@ impl TcpStream {
                     _ => panic!(),
                 };
                 self.imp.schedule_read(&mut me);
-                return Err(e)
+                return Err(e);
             }
 
             // If we're ready for a read then some previous 0-byte read has
@@ -331,14 +335,14 @@ impl TcpStream {
                     if amt > 0 && e.kind() == io::ErrorKind::WouldBlock {
                         me.read = State::Empty;
                         self.imp.schedule_read(&mut me);
-                        return Ok(amt)
+                        return Ok(amt);
                     } else if amt > 0 {
                         me.read = State::Error(e);
-                        return Ok(amt)
+                        return Ok(amt);
                     } else {
                         me.read = State::Empty;
                         self.imp.schedule_read(&mut me);
-                        return Err(e)
+                        return Err(e);
                     }
                 }
             }
@@ -363,16 +367,16 @@ impl TcpStream {
             State::Error(e) => return Err(e),
             other => {
                 me.write = other;
-                return Err(io::ErrorKind::WouldBlock.into())
+                return Err(io::ErrorKind::WouldBlock.into());
             }
         }
 
         if !me.iocp.registered() {
-            return Err(io::ErrorKind::WouldBlock.into())
+            return Err(io::ErrorKind::WouldBlock.into());
         }
 
         if bufs.is_empty() {
-            return Ok(0)
+            return Ok(0);
         }
 
         let len = bufs.iter().map(|b| b.len()).fold(0, |a, b| a + b);
@@ -397,7 +401,9 @@ impl StreamImp {
     fn schedule_connect(&self, addr: &SocketAddr) -> io::Result<()> {
         unsafe {
             trace!("scheduling a connect");
-            self.inner.socket.connect_overlapped(addr, &[], self.inner.read.as_mut_ptr())?;
+            self.inner
+                .socket
+                .connect_overlapped(addr, &[], self.inner.read.as_mut_ptr())?;
         }
         // see docs above on StreamImp.inner for rationale on forget
         mem::forget(self.clone());
@@ -421,11 +427,14 @@ impl StreamImp {
             _ => return,
         }
 
-        me.iocp.set_readiness(me.iocp.readiness() - Ready::readable());
+        me.iocp
+            .set_readiness(me.iocp.readiness() - Ready::readable());
 
         trace!("scheduling a read");
         let res = unsafe {
-            self.inner.socket.read_overlapped(&mut [], self.inner.read.as_mut_ptr())
+            self.inner
+                .socket
+                .read_overlapped(&mut [], self.inner.read.as_mut_ptr())
         };
         match res {
             // Note that `Ok(true)` means that this completed immediately and
@@ -471,18 +480,17 @@ impl StreamImp {
     ///
     /// A new writable event (e.g. allowing another write) will only happen once
     /// the buffer has been written completely (or hit an error).
-    fn schedule_write(&self,
-                      buf: Vec<u8>,
-                      mut pos: usize,
-                      me: &mut StreamInner) {
-
+    fn schedule_write(&self, buf: Vec<u8>, mut pos: usize, me: &mut StreamInner) {
         // About to write, clear any pending level triggered events
-        me.iocp.set_readiness(me.iocp.readiness() - Ready::writable());
+        me.iocp
+            .set_readiness(me.iocp.readiness() - Ready::writable());
 
         loop {
             trace!("scheduling a write of {} bytes", buf[pos..].len());
             let ret = unsafe {
-                self.inner.socket.write_overlapped(&buf[pos..], self.inner.write.as_mut_ptr())
+                self.inner
+                    .socket
+                    .write_overlapped(&buf[pos..], self.inner.write.as_mut_ptr())
             };
             match ret {
                 Ok(Some(transferred_bytes)) if me.instant_notify => {
@@ -534,7 +542,7 @@ fn read_done(status: &OVERLAPPED_ENTRY) {
             trace!("finished a read: {}", status.bytes_transferred());
             assert_eq!(status.bytes_transferred(), 0);
             me.read = State::Ready(());
-            return me2.add_readiness(&mut me, Ready::readable())
+            return me2.add_readiness(&mut me, Ready::readable());
         }
         s => me.read = s,
     }
@@ -579,11 +587,22 @@ fn write_done(status: &OVERLAPPED_ENTRY) {
 }
 
 impl Evented for TcpStream {
-    fn register(&self, poll: &Poll, token: Token,
-                interest: Ready, opts: PollOpt) -> io::Result<()> {
+    fn register(
+        &self,
+        poll: &Poll,
+        token: Token,
+        interest: Ready,
+        opts: PollOpt,
+    ) -> io::Result<()> {
         let mut me = self.inner();
-        me.iocp.register_socket(&self.imp.inner.socket, poll, token,
-                                     interest, opts, &self.registration)?;
+        me.iocp.register_socket(
+            &self.imp.inner.socket,
+            poll,
+            token,
+            interest,
+            opts,
+            &self.registration,
+        )?;
 
         unsafe {
             super::no_notify_on_instant_completion(self.imp.inner.socket.as_raw_socket() as HANDLE)?;
@@ -595,31 +614,42 @@ impl Evented for TcpStream {
         // successful connect will worry about generating writable/readable
         // events and scheduling a new read.
         if let Some(addr) = me.deferred_connect.take() {
-            return self.imp.schedule_connect(&addr).map(|_| ())
+            return self.imp.schedule_connect(&addr).map(|_| ());
         }
         self.post_register(interest, &mut me);
         Ok(())
     }
 
-    fn reregister(&self, poll: &Poll, token: Token,
-                  interest: Ready, opts: PollOpt) -> io::Result<()> {
+    fn reregister(
+        &self,
+        poll: &Poll,
+        token: Token,
+        interest: Ready,
+        opts: PollOpt,
+    ) -> io::Result<()> {
         let mut me = self.inner();
-        me.iocp.reregister_socket(&self.imp.inner.socket, poll, token,
-                                       interest, opts, &self.registration)?;
+        me.iocp.reregister_socket(
+            &self.imp.inner.socket,
+            poll,
+            token,
+            interest,
+            opts,
+            &self.registration,
+        )?;
         self.post_register(interest, &mut me);
         Ok(())
     }
 
     fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        self.inner().iocp.deregister(&self.imp.inner.socket,
-                                     poll, &self.registration)
+        self.inner()
+            .iocp
+            .deregister(&self.imp.inner.socket, poll, &self.registration)
     }
 }
 
 impl fmt::Debug for TcpStream {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("TcpStream")
-            .finish()
+        f.debug_struct("TcpStream").finish()
     }
 }
 
@@ -635,8 +665,7 @@ impl Drop for TcpStream {
             match self.inner().read {
                 State::Pending(_) | State::Empty => {
                     trace!("cancelling active TCP read");
-                    drop(super::cancel(&self.imp.inner.socket,
-                                       &self.imp.inner.read));
+                    drop(super::cancel(&self.imp.inner.socket, &self.imp.inner.read));
                 }
                 State::Ready(_) | State::Error(_) => {}
             }
@@ -645,13 +674,15 @@ impl Drop for TcpStream {
 }
 
 impl TcpListener {
-    pub fn new(socket: net::TcpListener)
-               -> io::Result<TcpListener> {
+    pub fn new(socket: net::TcpListener) -> io::Result<TcpListener> {
         let addr = socket.local_addr()?;
-        Ok(TcpListener::new_family(socket, match addr {
-            SocketAddr::V4(..) => Family::V4,
-            SocketAddr::V6(..) => Family::V6,
-        }))
+        Ok(TcpListener::new_family(
+            socket,
+            match addr {
+                SocketAddr::V4(..) => Family::V4,
+                SocketAddr::V6(..) => Family::V6,
+            },
+        ))
     }
 
     fn new_family(socket: net::TcpListener, family: Family) -> TcpListener {
@@ -688,7 +719,7 @@ impl TcpListener {
 
         self.imp.schedule_accept(&mut me);
 
-        return ret
+        return ret;
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
@@ -696,9 +727,11 @@ impl TcpListener {
     }
 
     pub fn try_clone(&self) -> io::Result<TcpListener> {
-        self.imp.inner.socket.try_clone().map(|s| {
-            TcpListener::new_family(s, self.imp.inner.family)
-        })
+        self.imp
+            .inner
+            .socket
+            .try_clone()
+            .map(|s| TcpListener::new_family(s, self.imp.inner.family))
     }
 
     #[allow(deprecated)]
@@ -736,18 +769,23 @@ impl ListenerImp {
     fn schedule_accept(&self, me: &mut ListenerInner) {
         match me.accept {
             State::Empty => {}
-            _ => return
+            _ => return,
         }
 
-        me.iocp.set_readiness(me.iocp.readiness() - Ready::readable());
+        me.iocp
+            .set_readiness(me.iocp.readiness() - Ready::readable());
 
         let res = match self.inner.family {
             Family::V4 => TcpBuilder::new_v4(),
             Family::V6 => TcpBuilder::new_v6(),
-        }.and_then(|builder| unsafe {
+        }
+        .and_then(|builder| builder.to_tcp_stream())
+        .and_then(|stream| unsafe {
             trace!("scheduling an accept");
-            self.inner.socket.accept_overlapped(&builder, &mut me.accept_buf,
-                                                self.inner.accept.as_mut_ptr())
+            self.inner
+                .socket
+                .accept_overlapped(&stream, &mut me.accept_buf, self.inner.accept.as_mut_ptr())
+                .map(|accepted| (stream, accepted))
         });
         match res {
             Ok((socket, _)) => {
@@ -780,13 +818,15 @@ fn accept_done(status: &OVERLAPPED_ENTRY) {
         _ => unreachable!(),
     };
     trace!("finished an accept");
-    let result = me2.inner.socket.accept_complete(&socket).and_then(|()| {
-        me.accept_buf.parse(&me2.inner.socket)
-    }).and_then(|buf| {
-        buf.remote().ok_or_else(|| {
-            io::Error::new(ErrorKind::Other, "could not obtain remote address")
-        })
-    });
+    let result = me2
+        .inner
+        .socket
+        .accept_complete(&socket)
+        .and_then(|()| me.accept_buf.parse(&me2.inner.socket))
+        .and_then(|buf| {
+            buf.remote()
+                .ok_or_else(|| io::Error::new(ErrorKind::Other, "could not obtain remote address"))
+        });
     me.accept = match result {
         Ok(remote_addr) => State::Ready((socket, remote_addr)),
         Err(e) => State::Error(e),
@@ -795,11 +835,22 @@ fn accept_done(status: &OVERLAPPED_ENTRY) {
 }
 
 impl Evented for TcpListener {
-    fn register(&self, poll: &Poll, token: Token,
-                interest: Ready, opts: PollOpt) -> io::Result<()> {
+    fn register(
+        &self,
+        poll: &Poll,
+        token: Token,
+        interest: Ready,
+        opts: PollOpt,
+    ) -> io::Result<()> {
         let mut me = self.inner();
-        me.iocp.register_socket(&self.imp.inner.socket, poll, token,
-                                     interest, opts, &self.registration)?;
+        me.iocp.register_socket(
+            &self.imp.inner.socket,
+            poll,
+            token,
+            interest,
+            opts,
+            &self.registration,
+        )?;
 
         unsafe {
             super::no_notify_on_instant_completion(self.imp.inner.socket.as_raw_socket() as HANDLE)?;
@@ -810,25 +861,36 @@ impl Evented for TcpListener {
         Ok(())
     }
 
-    fn reregister(&self, poll: &Poll, token: Token,
-                  interest: Ready, opts: PollOpt) -> io::Result<()> {
+    fn reregister(
+        &self,
+        poll: &Poll,
+        token: Token,
+        interest: Ready,
+        opts: PollOpt,
+    ) -> io::Result<()> {
         let mut me = self.inner();
-        me.iocp.reregister_socket(&self.imp.inner.socket, poll, token,
-                                       interest, opts, &self.registration)?;
+        me.iocp.reregister_socket(
+            &self.imp.inner.socket,
+            poll,
+            token,
+            interest,
+            opts,
+            &self.registration,
+        )?;
         self.imp.schedule_accept(&mut me);
         Ok(())
     }
 
     fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        self.inner().iocp.deregister(&self.imp.inner.socket,
-                                     poll, &self.registration)
+        self.inner()
+            .iocp
+            .deregister(&self.imp.inner.socket, poll, &self.registration)
     }
 }
 
 impl fmt::Debug for TcpListener {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("TcpListener")
-            .finish()
+        f.debug_struct("TcpListener").finish()
     }
 }
 
@@ -839,12 +901,12 @@ impl Drop for TcpListener {
             match self.inner().accept {
                 State::Pending(_) => {
                     trace!("cancelling active TCP accept");
-                    drop(super::cancel(&self.imp.inner.socket,
-                                       &self.imp.inner.accept));
+                    drop(super::cancel(
+                        &self.imp.inner.socket,
+                        &self.imp.inner.accept,
+                    ));
                 }
-                State::Empty |
-                State::Ready(_) |
-                State::Error(_) => {}
+                State::Empty | State::Ready(_) | State::Error(_) => {}
             }
         }
     }

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -12,10 +12,11 @@ use std::sync::{Mutex, MutexGuard};
 
 #[allow(unused_imports)]
 use net2::{UdpBuilder, UdpSocketExt};
-use winapi::*;
 use miow::iocp::CompletionStatus;
 use miow::net::SocketAddrBuf;
 use miow::net::UdpSocketExt as MiowUdpSocketExt;
+use windows_sys::Win32::Networking::WinSock::WSAEMSGSIZE;
+use windows_sys::Win32::System::IO::OVERLAPPED_ENTRY;
 
 use {poll, Ready, Poll, PollOpt, Token};
 use event::Evented;
@@ -160,7 +161,7 @@ impl UdpSocket {
                 // then don't actually read any data, just return an error.
                 if buf.len() < data.len() {
                     me.read = State::Ready(data);
-                    Err(io::Error::from_raw_os_error(WSAEMSGSIZE as i32))
+                    Err(io::Error::from_raw_os_error(WSAEMSGSIZE))
                 } else {
                     let r = if let Some(addr) = me.read_buf.to_socket_addr() {
                         buf.write(&data).unwrap();


### PR DESCRIPTION
## Description

`winapi` 0.2.x doesn't compile for ARM, so we need to update our `mio` fork to use `winapi` 0.3.x.

## Testing

- [x] Manually tested with a local build of Warp that used a `[patch]` directive to point at my local copy of `mio` with this code applied.  PTYs spawn and work as expected.